### PR TITLE
Move completed column next to leeching column on torrents page

### DIFF
--- a/resources/views/torrent/torrents.blade.php
+++ b/resources/views/torrent/torrents.blade.php
@@ -126,9 +126,9 @@
           <th class="torrents__header-name">Name</th>
           <th class="torrents__header_time">Time</th>
           <th class="torrents__header-size">Size</th>
-          <th class="completed">C</th>
           <th class="seeders">S</th>
           <th class="leechers">L</th>
+          <th class="completed">C</th>
         </tr>
         </thead>
         @foreach($torrents as $torrent)
@@ -200,9 +200,9 @@
             </td>
             <td>{{ $torrent->age() }}</td>
             <td>{{ \App\Helpers\StringHelper::formatBytes($torrent->size) }}</td>
-            <td>{{ $torrent->times_completed }}</td>
             <td>{{ $torrent->seeders }}</td>
             <td>{{ $torrent->leechers }}</td>
+            <td>{{ $torrent->times_completed }}</td>
           </tr>
         @endforeach
       </table>


### PR DESCRIPTION
This commit changes the format of the colums on the torrents page to S | L | C which is much more common on torrent sites than the current C | S | L format.