### PR TITLE
Fix S L C format on featured torrents block

### DIFF
--- a/resources/views/home/home.blade.php
+++ b/resources/views/home/home.blade.php
@@ -32,9 +32,9 @@
         <tr>
           <th>Name</th>
           <th>Size</th>
-          <th>Seeders</th>
-          <th>Leechers</th>
-          <th>Completed</th>
+          <th>{{ trans('torrent.short-seeds') }} </th>
+          <th>{{ trans('torrent.short-leechs') }} </th>
+          <th>{{ trans('torrent.short-completed') }} </th>
           <th>Featured By</th>
         </tr>
         </thead>


### PR DESCRIPTION
This should actually change the format to S L C since the previous change to the featured.blade.php did not.